### PR TITLE
doc: crc-extension test cases

### DIFF
--- a/docs/scenarios/crc-extension/1-extension-installation.md
+++ b/docs/scenarios/crc-extension/1-extension-installation.md
@@ -1,0 +1,38 @@
+# Extension installation test
+This document covers how to complete the test cases from the first section of the `OpenShift Local extension` test sheet. In the first test case it is presumed that the `OpenShift Local extension` is not installed in the machine used.
+
+### OSL extension installation from the PD catalog
+Check the process on the [Extension installation section of the README](https://github.com/crc-org/crc-extension?tab=readme-ov-file#extension-installation)
+
+### OSL extension installation via OCI URI - latest tag
+Check the process on the [Extension installation section of the README](https://github.com/crc-org/crc-extension?tab=readme-ov-file#extension-installation)
+
+### Dependency (on sso) is installed along with crc-ext
+Once installed, go to the **Installed** section under the **Extensions** page and you should be able to find the `Red Hat OpenShift Local` and `Red Hat Authentication` extensions
+
+### Extensions verification - enable, disable, remove
+- Once installed, go to the **Installed** section under the **Extensions** page, and look for `Red Hat OpenShift Local`
+- If the status of the extension is `ACTIVE`, disable it by clicking on the `Stop` button. Status should turn to `DISABLED`
+- Enable the extension again by clicking on the `Start` button. Status should turn to `ACTIVE`
+- Remove the extension by clicking on the `Stop` button and then on the `Delete` button. This should have the following effects:
+	- The extension card disappears from the **Installed** section
+	- The extension appears available again to be installed in the **Catalog** section
+	- The extension card disappears from the **Settings/Resources** section
+	- The extension card disappears from the **Settings/Preferences** section and from the navbar on the left
+- Install the extension again for the next test cases
+
+### Extensions verification - Settings/Resources provider card is present, contains buttons,etc
+Go to **Settings/Resources** and find the `OpenShift Local` card, it should contain either:
+- The `Start/Restart/Stop/Delete` buttons (if you have a crc instance), or
+- The `Create new...` button to make a new instance (if you don't have any), or
+- A text explaining what OpenShift Local is if you don't have crc installed
+
+### Extensions verification - Settings/Preferences contains new record and property to configure
+- Go to **Settings/Preferences** and find the `Red Hat OpenShift Local` entry, it should contain the `Preset` setting, and you should be able to change from `openshift` to `microshift` and vice versa
+- Also a new entry (`Extension: Red Hat OpenShift Local`) should be available in the navbar on the left
+
+### Extensions verification - Dashboard provider card is present, contains buttons,etc
+Go to the **Dashboard** page and find the `OpenShift Local` card, it should contain either:
+- The `RUNNING` label if you have a crc instance created and running, or
+- The `Initialize and Start` or `Initialize` button if you don't have a crc instance, or
+- The `NOT-INSTALLED` label, and the `View detection checks` and `Install` buttons (unless you're on Linux)

--- a/docs/scenarios/crc-extension/2-crc-installation.md
+++ b/docs/scenarios/crc-extension/2-crc-installation.md
@@ -1,0 +1,33 @@
+# CRC installation
+This document covers how to complete the test cases from the second section of the `OpenShift Local extension` test sheet. In the first test case it is presumed that the `OpenShift Local extension` is installed in the machine used but the `OpenShift Local` binaries are not.
+
+You can find the process as well in the [OpenShift Local installation section from the README](https://github.com/crc-org/crc-extension?tab=readme-ov-file#openshift-local-installation).
+
+### Can update crc - updates existing crc with the latest
+- Download an older version of `crc`, you can find the different releases [here](https://github.com/crc-org/crc/releases)
+- Install the downloaded version, the process varies depending on your OS
+- Check that `crc` is correctly downloaded (`crc version` e.g.)
+- On **Podman Desktop**, go to the **Dashboard** page and find the `OpenShift Local` card, it should contain a `Update to X.X.X` button (where X.X.X is the latest release)
+- Click on it, a dialog should appear to confirm the update, click on the `Yes` button
+- **Podman Desktop** should download the installer (you can check the progress on the download on the bottom) and open the installation wizard
+- Follow the instructions on the wizard and after finishing the installation the `Update to X.X.X` button should've disappeared and you should have the newer version (check with `crc version`)
+- Uninstall `crc` for the next test cases
+
+### Can install crc - requirements check
+Go to the **Dashboard** page, on the `OpenShift Local` card you will find an `Install` button (unless you're on Linux). Click on it, several green checks should appear
+
+### Can install crc - crc binary installation
+- A dialog to confirm the `crc` installation should've appeared, click on the `Yes` button
+- **Podman Desktop** should download the installer (check the progress on the download on the bottom) and open the installation wizard.
+- Follow the instructions on the wizard and after finishing the installation a dialog that prompts you to restart the computer should appear. Click on `Restart`.
+- Open **Podman Desktop** when the computer finishes restarting, on the **Dashboard** you should find that the `OpenShift Local` card has a version label and an `INSTALLED BUT NOT READY` status
+
+### Can install crc - openshift bundle downloaded
+During the cluster initialization process, if you didn't have the openshift bundle on your machine and you had the `openshift` preset, you should've spotted its download in the bottom of the Podman Desktop UI
+
+### Can install crc - preset dialog offered
+On the **Dashboard**, click on the `Initialize and start` button, a dialog that prompts you to choose a preset should appear
+
+### Can install crc - crc binary installed - task manager check
+Once `crc` has been initialized and started, open the **Task Manager**. A process called `crc.exe` should be running
+

--- a/docs/scenarios/crc-extension/3-main-functionality.md
+++ b/docs/scenarios/crc-extension/3-main-functionality.md
@@ -1,0 +1,27 @@
+# Main functionality
+This document covers how to complete the test cases from the third section of the `OpenShift Local extension` test sheet. In the first test case it is presumed that the `OpenShift Local extension` and the `OpenShift Local` binaries are installed in the machine.
+
+### OpenShift bundle/cluster can be started
+- On **Settings/Resources**, make sure you have no cluster initialized. `Stop` it and delete if you do
+- Go to **Settings/Preferences** and make sure you have the preset set to `openshift` in the `Extension: Red Hat OpenShift Local` section
+- Go to **Settings/Resources** and click on the `Create new...` button on the `OpenShift Local` card
+- A new window should open, leave the default settings and click on the `Create` button
+- After a while, the OpenShift cluster should be initialized and started
+
+### Microshift bundle/cluster can be started
+Exactly like the previous test case, but changing the preset from `openshift` to `microshift`
+
+### Stop, Start, Restart
+On **Settings/Resources**, try to `Stop`, `Start`, and `Restart` the current cluster
+
+### Preset can be changed and cluster started-restarted
+- Make sure your cluster is stopped by going to the `OpenShift Local` card in **Settings/Resources** and clicking on `Stop` if the status is `RUNNING`
+- Go to **Settings/Preferences** and swap the preset setting in `Extension: Red Hat OpenShift Local` to the other one 
+- Go back to **Settings/Resources** and start the cluster. After a while the status should've changed from `STARTING` to `RUNNING`
+
+### Can deploy a pod/containers (ie. httpd-24) to a cluster
+Follow the steps on the [Deployment to OpenShift Local section of the README](https://github.com/crc-org/crc-extension?tab=readme-ov-file#deployment-to-openshift-local)
+
+### Can delete the cluster
+- Go to **Settings/Resources**, on the `OpenShift Local` card, click on the `Stop` button. After it has finished stopping, click on the `Delete` button
+- The button `Create new...` should've appeared again in the card


### PR DESCRIPTION
Adds the documentation for the tests cases on the OpenShift Local extension testing tracker. Closes [#312](https://github.com/crc-org/crc-extension/issues/312) partially